### PR TITLE
Fix custom requester fields

### DIFF
--- a/lib/eversign/mappings/document.rb
+++ b/lib/eversign/mappings/document.rb
@@ -51,7 +51,7 @@ module Eversign
         mapping Eversign::Models::Document
 
         property :document_hash, :template_id, :sandbox, :is_draft, :title, :message, :use_signer_order, :reminders, :require_all_signers,
-                 :redirect, :redirect_decline, :client, :expires, :embedded_signing_enabled, :requester_email, :is_template,
+                 :redirect, :redirect_decline, :client, :expires, :embedded_signing_enabled, :custom_requester_email, :custom_requester_name, :is_template,
                  :is_completed, :is_archived, :is_deleted, :is_trashed, :is_cancelled, :embedded, :in_person, :permission,
                  :use_hidden_tags
         property :files, plural: true, include: File

--- a/lib/eversign/models/document.rb
+++ b/lib/eversign/models/document.rb
@@ -2,7 +2,7 @@ module Eversign
 	module Models
 		class Document
 	    attr_accessor :document_hash, :template_id, :sandbox, :is_draft, :title, :message, :use_signer_order, :reminders, :require_all_signers,
-		    				  :redirect, :redirect_decline, :client, :expires, :embedded_signing_enabled, :requester_email, :is_template,
+		    				  :redirect, :redirect_decline, :client, :expires, :embedded_signing_enabled, :custom_requester_email, :custom_requester_name, :is_template,
 		    				  :is_completed, :is_archived, :is_deleted, :is_trashed, :is_cancelled, :embedded, :in_person, :permission,
 		    				  :files, :signers, :recipients, :meta, :fields, :use_hidden_tags
 


### PR DESCRIPTION
**Describe the bug**
1. `custom_requester_name` is missing
2. `custom_requester_email` is missing, but have `requester_email` instead, which doesn't reflect the key in the docs  (https://eversign.com/api/documentation/methods#create-document)

**Steps**
```
document = Eversign::Models::Document.new
document.requester_name = "John Smith"
=> NoMethodError: undefined method `requester_name' for #<Eversign::Models::Document:0x0000562eb305cfc0>

document.custom_requester_name
=> NoMethodError: undefined method `custom_requester_name' for #<Eversign::Models::Document:0x0000562eb305cfc0>

document.methods.grep /requester/
=> [:requester_email=, :requester_email]
```
**Expected behavior**
`custom_requester_name` and `custom_requester_name` setters and getters should be present
